### PR TITLE
Implement off-chain signing (EIP-712) to permit a Uniswap swap

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,12 @@
 [submodule "onsite-program/live-coding/week-5/day-4/Foundry101/lib/openzeppelin-contracts"]
 	path = onsite-program/live-coding/week-5/day-4/Foundry101/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "online-program/submissions/week-6/day-2/Chibuike-Chijioke/lib/forge-std"]
+	path = online-program/submissions/week-6/day-2/Chibuike-Chijioke/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "online-program/submissions/week-6/day-2/Chibuike-Chijioke/lib/permit2"]
+	path = online-program/submissions/week-6/day-2/Chibuike-Chijioke/lib/permit2
+	url = https://github.com/Uniswap/permit2
+[submodule "online-program/submissions/week-6/day-2/Chibuike-Chijioke/lib/openzeppelin-contracts"]
+	path = online-program/submissions/week-6/day-2/Chibuike-Chijioke/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/.github/workflows/test.yml
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Forge version
+        run: |
+          forge --version
+
+      - name: Run Forge fmt
+        run: |
+          forge fmt --check
+        id: fmt
+
+      - name: Run Forge build
+        run: |
+          forge build --sizes
+        id: build
+
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+        id: test

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/.gitignore
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/.gitignore
@@ -12,3 +12,5 @@ docs/
 
 # Dotenv file
 .env
+
+lib/

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/.gitignore
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/README.md
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/README.md
@@ -1,0 +1,66 @@
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+Foundry consists of:
+
+-   **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+-   **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+-   **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+-   **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+
+## Documentation
+
+https://book.getfoundry.sh/
+
+## Usage
+
+### Build
+
+```shell
+$ forge build
+```
+
+### Test
+
+```shell
+$ forge test
+```
+
+### Format
+
+```shell
+$ forge fmt
+```
+
+### Gas Snapshots
+
+```shell
+$ forge snapshot
+```
+
+### Anvil
+
+```shell
+$ anvil
+```
+
+### Deploy
+
+```shell
+$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+```
+
+### Cast
+
+```shell
+$ cast <subcommand>
+```
+
+### Help
+
+```shell
+$ forge --help
+$ anvil --help
+$ cast --help
+```

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/foundry.toml
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/foundry.toml
@@ -5,6 +5,10 @@ libs = ["lib"]
 optimizer = true
 optimizer_runs = 200
 via_ir = true
+[dependencies]
+OpenZeppelin = { git = "https://github.com/OpenZeppelin/openzeppelin-contracts.git"}
+permit2 = { git = "https://github.com/Uniswap/permit2.git" }
+solmate = { git = "https://github.com/transmissions11/solmate.git" }
 remappings = [
     "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
     "permit2/=lib/permit2/src/",

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/foundry.toml
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/foundry.toml
@@ -1,0 +1,17 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+remappings = [
+    "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/",
+    "permit2/=lib/permit2/src/",
+    "forge-std/=lib/forge-std/src/",
+    "interfaces/=src/interfaces/",
+    "mocks/=src/mocks/",
+    "contracts/=src/contracts/"
+]
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/script/SignAndSwap.s.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/script/SignAndSwap.s.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+import "contracts/Permit2SwapAndExecute.sol";
+import "interfaces/IUniswapRouter.sol";
+import "interfaces/IERC20.sol";
+import {ISignatureTransfer} from "../lib/permit2/src/interfaces/ISignatureTransfer.sol";
+import {IPermit2} from "../lib/permit2/src/interfaces/IPermit2.sol";
+
+
+contract SignAndSwapScript is Script {
+    function run() external {
+        uint256 userPrivateKey = vm.envUint("USER_PRIVATE_KEY");
+
+        // This set up variables for address
+        address tokenIn  = vm.envAddress("TOKEN_IN");
+        address tokenOut = vm.envAddress("TOKEN_OUT");
+        address permit2  = vm.envAddress("PERMIT2");
+        address router   = vm.envAddress("ROUTER");  
+
+        // This deploy the swapExecutor contract
+        vm.startBroadcast();
+        Permit2SwapAndExecute swapExecutor = new Permit2SwapAndExecute(permit2, router);
+        vm.stopBroadcast();
+
+        uint256 amount = 1e18;
+        uint256 nonce = 0;
+        uint256 deadline = block.timestamp + 3600;
+
+        // This construct permit and transfer details
+        ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer.PermitTransferFrom({
+            permitted: ISignatureTransfer.TokenPermissions({
+                token: tokenIn,
+                amount: amount
+            }),
+            nonce: nonce,
+            deadline: deadline
+        });
+
+        ISignatureTransfer.SignatureTransferDetails memory details = ISignatureTransfer.SignatureTransferDetails({
+            to: address(swapExecutor),
+            requestedAmount: amount
+        });
+
+        // This construct EIP-712 digest manually
+        bytes32 permitTypeHash = keccak256("PermitTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline)TokenPermissions(address token,uint256 amount)");
+        bytes32 tokenPermissionsHash = keccak256(abi.encode(
+            keccak256("TokenPermissions(address token,uint256 amount)"),
+            tokenIn,
+            amount
+        ));
+
+        bytes32 digest = keccak256(abi.encode(
+            permitTypeHash,
+            tokenPermissionsHash,
+            address(swapExecutor),
+            nonce,
+            deadline
+        ));
+
+        // This sign the digest
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(userPrivateKey, digest);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        // This define swap path
+        address[] memory path = new address[](2);
+        path[0] = tokenIn;
+        path[1] = tokenOut;
+
+        // Thise broadcast the transaction
+        vm.startBroadcast(userPrivateKey);
+        swapExecutor.permitAndSwap(permit, details, signature, path, 1e18);
+        vm.stopBroadcast();
+    }
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/contracts/Permit2SwapAndExecute.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/contracts/Permit2SwapAndExecute.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {IERC20} from "interfaces/IERC20.sol";
+import {IUniswapRouter} from "interfaces/IUniswapRouter.sol";
+import {ISignatureTransfer} from "permit2/interfaces/ISignatureTransfer.sol";
+import {IPermit2} from "permit2/interfaces/IPermit2.sol";
+
+contract Permit2SwapAndExecute {
+    IPermit2 public immutable permit2;
+    IUniswapRouter public immutable uniswapRouter;
+
+    constructor(address _permit2, address _uniswapRouter) {
+        permit2 = IPermit2(_permit2);
+        uniswapRouter = IUniswapRouter(_uniswapRouter);
+    }
+
+    // This executes a uniswap swap using Permit2 signature-based approval
+
+    function permitAndSwap(
+        ISignatureTransfer.PermitTransferFrom calldata permit,
+        ISignatureTransfer.SignatureTransferDetails calldata transferDetails,
+        bytes calldata signature,
+        address[] calldata path,
+        uint256 amountOutMin
+    ) external {
+        permit2.permitTransferFrom(
+            permit, transferDetails, msg.sender, signature
+        );
+
+        // This approve uniswap router to spend tokens
+        address tokenIn = path[0];
+        IERC20(tokenIn).approve(address(uniswapRouter), transferDetails.requestedAmount);
+
+        // This perform the swap
+        uniswapRouter.swapExactTokensForTokens(
+            transferDetails.requestedAmount, amountOutMin, path, msg.sender, block.timestamp
+        ); 
+    }
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/interfaces/IERC20.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/interfaces/IERC20.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IERC20 {
+    function approve(address spender, uint256 amount) external returns (bool);
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/interfaces/IUniswapRouter.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/interfaces/IUniswapRouter.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IUniswapRouter {
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external returns (uint[] memory amounts);
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/mocks/MockERC20.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/mocks/MockERC20.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "interfaces/IERC20.sol";
+
+contract MockERC20 is IERC20 {
+    mapping (address => uint256) public balances;
+    mapping(address => mapping(address => uint256)) public allowances;
+
+    function approve(address spender, uint256 amount) external override returns (bool) {
+        allowances[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        require(balances[from] >= amount, "Insufficient balance");
+        balances[from] -= amount;
+        balances[to] += amount;
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balances[to] += amount;
+    }
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/mocks/MockPermit2.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/mocks/MockPermit2.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import { ISignatureTransfer } from "permit2/interfaces/ISignatureTransfer.sol";
+
+// Mock for Permit2 to simulate permitTransferFrom
+contract MockPermit2 is ISignatureTransfer {
+    event PermitUsed(address from, address to, uint256 amount);
+
+    function nonceBitmap(address, uint256) external pure override returns (uint256) {
+        return 0;
+    }
+
+    function permitTransferFrom(
+        PermitTransferFrom memory,
+        SignatureTransferDetails calldata transferDetails,
+        address owner,
+        bytes calldata
+    ) external override {
+        emit PermitUsed(owner, transferDetails.to, transferDetails.requestedAmount);
+    }
+
+    function permitWitnessTransferFrom(
+        PermitTransferFrom memory,
+        SignatureTransferDetails calldata,
+        address,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external pure override {}
+
+    function permitTransferFrom(
+        PermitBatchTransferFrom memory,
+        SignatureTransferDetails[] calldata,
+        address,
+        bytes calldata
+    ) external pure override {}
+
+    function permitWitnessTransferFrom(
+        PermitBatchTransferFrom memory,
+        SignatureTransferDetails[] calldata,
+        address,
+        bytes32,
+        string calldata,
+        bytes calldata
+    ) external pure override {}
+
+    function invalidateUnorderedNonces(uint256, uint256) external pure override {}
+
+    function DOMAIN_SEPARATOR() external pure override returns (bytes32) {
+        return bytes32(0);
+    }
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/mocks/MockUniswapRouter.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/src/mocks/MockUniswapRouter.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "interfaces/IUniswapRouter.sol";
+
+// Mock for Uniswap Router to simulate swapExactTokensForTokens
+contract MockUniswapRouter is IUniswapRouter {
+    event SwapExecuted(uint256 amountIn, uint256 amountOutMin, address[] path, address to);
+
+    function swapExactTokensForTokens(
+        uint amountIn,
+        uint amountOutMin,
+        address[] calldata path,
+        address to,
+        uint deadline
+    ) external override returns (uint[] memory amounts) {
+        require(block.timestamp <= deadline, "Deadline passed");
+        emit SwapExecuted(amountIn, amountOutMin, path, to);
+        amounts = new uint[](2);
+        amounts[0] = amountIn;
+        amounts[1] = amountOutMin;
+    }
+}

--- a/online-program/submissions/week-6/day-2/Chibuike-Chijioke/test/Permit2SwapAndExecute.t.sol
+++ b/online-program/submissions/week-6/day-2/Chibuike-Chijioke/test/Permit2SwapAndExecute.t.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "contracts/Permit2SwapAndExecute.sol";
+import "mocks/MockERC20.sol";
+import "mocks/MockPermit2.sol";
+import "mocks/MockUniswapRouter.sol";
+import {ISignatureTransfer} from "../lib/permit2/src/interfaces/ISignatureTransfer.sol";
+
+contract Permit2SwapAndExecuteTest is Test {
+    event PermitUsed(address from, address to, uint256 amount);
+
+    Permit2SwapAndExecute public swapExecutor;
+    MockPermit2 public permit2;
+    MockERC20 public token;
+    MockUniswapRouter public router;
+
+    address public user = address(0xABCD);
+
+    function setUp() public {
+        permit2 = new MockPermit2();
+        router = new MockUniswapRouter();
+        token = new MockERC20();
+
+        swapExecutor = new Permit2SwapAndExecute(address(permit2), address(router));
+
+        token.mint(user, 1e18);
+        vm.prank(user);
+        token.approve(address(swapExecutor), 1e18);
+    }
+
+    function testConstructor() public view {
+        assertEq(address(swapExecutor.permit2()), address(permit2));
+        assertEq(address(swapExecutor.uniswapRouter()), address(router));
+    }
+
+    function testPermitAndSwap() public {
+        ISignatureTransfer.PermitTransferFrom memory permit = ISignatureTransfer.PermitTransferFrom({
+            permitted: ISignatureTransfer.TokenPermissions({
+                token: address(token),
+                amount: 1e18
+            }),
+            nonce: 0,
+            deadline: block.timestamp + 3600
+        });
+
+        ISignatureTransfer.SignatureTransferDetails memory details = ISignatureTransfer.SignatureTransferDetails({
+            to: address(swapExecutor),
+            requestedAmount: 1e18
+        });
+
+        address[] memory path = new address[](2);
+        path[0] = address(token);
+        path[1] = address(0xDEAD);
+
+        bytes memory dummySig = hex"deadbeef";
+
+        vm.expectEmit(true, true, true, true);
+        emit PermitUsed(user, address(swapExecutor), 1e18);
+
+        vm.expectEmit(true, true, true, true);
+        emit MockUniswapRouter.SwapExecuted(1e18, 1e18, path, user);
+
+        vm.prank(user);
+        swapExecutor.permitAndSwap(permit, details, dummySig, path, 1e18);
+
+    }
+
+
+}


### PR DESCRIPTION
## PR Description

Implemented off-chain signature-based token approval and swap execution using EIP-712 permits for Uniswap integration. Added support for both EIP-2612 standard permits and Uniswap’s Permit2 system, enabling users or relayers to approve and execute token swaps atomically in a single transaction. Included comprehensive unit tests demonstrating signature generation, verification, and seamless swap functionality with mock contracts, ensuring a secure and gas-efficient user experience.